### PR TITLE
Fix module exports for browser ws

### DIFF
--- a/ws/browser-ws.js
+++ b/ws/browser-ws.js
@@ -356,4 +356,4 @@
   };
 
   console.log("pink", exports.DashSightWs, exports);
-})(("undefined" !== typeof module && module) || window);
+})(("undefined" !== typeof module && module.exports) || window);


### PR DESCRIPTION
This resolves an issue with importing dashsight browser websockets like below in Vite / ESM

```js
import { DashSightWs } from 'dashsight/ws/browser-ws.js'
```

See https://github.com/jojobyte/dashsight-vite-test/commit/cb3177c02a44ec4e2cda50e840827ea68ad03a8b