### PR TITLE
fix: instantSend 400 request error

### DIFF
--- a/dashsight.js
+++ b/dashsight.js
@@ -146,10 +146,18 @@
       let reqObj = {
         method: "POST",
         url: instUrl,
-        json: true,
-        form: {
-          rawtx: hexTx,
+        // This does not appear to work
+        // json: {
+        //   rawtx: hexTx,
+        // },
+        // Though inelegant, this does work
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
         },
+        body: JSON.stringify({
+          rawtx: hexTx,
+        }),
       };
       let txResp = await request(reqObj);
       if (!txResp.ok) {


### PR DESCRIPTION
This bug is related to implementing https://github.com/dashhive/crowdnode.js for https://github.com/dashhive/crowdnode.js/issues/47 in https://github.com/dashhive/crowdnode-ui/issues/1

It happens at this timestamp in my stream https://youtu.be/Hik0sLqudYg?t=3025

When executing `CrowdNode.signup` or `CrowdNode.accept` in browser, the error below is thrown. This attempts to fix the error and let you continue the CrowdNode signup and accept process.

```
POST https://dashsight.dashincubator.dev/insight-api/tx/sendix 400
Uncaught (in promise) TypeError: Failed to execute 'text' on 'Response': body stream already read
```

![image](https://user-images.githubusercontent.com/184880/213895121-6e658a12-1f24-49a0-aceb-916160e8a59a.png)

The problem appears to be that `json: true,` and `form: { rawtx: hexTx, },` are not valid options for the `@root/request` library and do not properly set the headers for the request.

```js
// this was attempted but did not fix the issue entirely, just changed the error.
json: {
  rawtx: hexTx,
},
```

